### PR TITLE
Update hiramu-cli to version 0.1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,9 +910,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiramu"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc93a83b89f788697d07293e09e543efcf94bc4c825552569111b82b2a12c169"
+checksum = "b342c067012b413bac34c3e93cf80e1c062b2b881d2495e922b757abf94e047f"
 dependencies = [
  "async-stream",
  "aws-config",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "hiramu-cli"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiramu-cli"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "A command-line interface tool for interacting with large language models (LLMs) on AWS Bedrock and generating text based on prompts."
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,92 +1,100 @@
-# Hiramu CLI
+Here is an improved version of the README.md file:
+
+**Hiramu CLI**
+================
 
 Hiramu CLI is a powerful command-line interface for interacting with language models. It provides a seamless way to ask questions and generate text using various models, including Claude (Haiku and Sonnet) and Mistral (7B, 8x7B, and Large).
 
-## Features
+**Features**
+------------
 
-- Ask questions to language models using a simple command-line interface
-- Support for multiple models, including Claude and Mistral
-- Customizable options for region, profile, maximum number of tokens, temperature, and model alias
-- Interactive input using the `{input}` placeholder in prompts
-- Real-time streaming of generated text
+* Ask questions to language models using a simple command-line interface
+* Support for multiple models, including Claude and Mistral
+* Customizable options for region, profile, maximum number of tokens, temperature, and model alias
+* Interactive input using the `{input}` placeholder in prompts
+* Real-time streaming of generated text
 
-## Installation
+**Installation**
+---------------
 
 To install Hiramu CLI, ensure you have Rust installed on your system. Then, run the following command:
-
 ```bash
 cargo install hiramu-cli
 ```
+**Usage**
+-----
 
-## Usage
-
-To ask a question to a language model, use the `prompt` subcommand followed by the question. You can specify additional options to customize the behavior of the CLI.
-
+To ask a question to a language model, use the `generate` subcommand followed by the question. You can specify additional options to customize the behavior of the CLI.
 ```bash
-hiramu-cli prompt "What is the capital of France?" -r us-west-2 -p bedrock -m 100 -t 0.7 -M haiku
+hiramu-cli generate "What is the capital of France?" -r us-west-2 -p bedrock -m 100 -t 0.7 -M haiku
 ```
-
 ### Options
 
-- `-r, --region <REGION>`: The region to use (default: "us-west-2").
-- `-p, --profile <PROFILE>`: The profile to use (default: "bedrock").
-- `-m, --maxtoken <MAXTOKEN>`: The maximum number of tokens to generate (default: 100).
-- `-t, --temperature <TEMPERATURE>`: The temperature to use for generation (default: 0.7).
-- `-M, --model <MODEL>`: The model alias to use for generation (default: "haiku").
+* `-r, --region <REGION>`: The region to use (default: "us-west-2").
+* `-p, --profile <PROFILE>`: The profile to use (default: "bedrock").
+* `-m, --maxtoken <MAXTOKEN>`: The maximum number of tokens to generate (default: 100).
+* `-t, --temperature <TEMPERATURE>`: The temperature to use for generation (default: 0.7).
+* `-M, --model <MODEL>`: The model alias to use for generation (default: "haiku").
 
 ### Interactive Input
 
 Hiramu CLI supports interactive input using the `{input}` placeholder in prompts. When the placeholder is present, the CLI will prompt you to enter the input, which will be inserted into the prompt before sending it to the language model.
-
 ```bash
-hiramu-cli prompt "Translate the following text from English to French: {input}" -M sonnet
+hiramu-cli generate "Translate the following text from English to French: {input}" -M sonnet
 ```
-
 This feature allows you to provide dynamic input to the language model during runtime.
 
 ### Model Aliases
 
 Hiramu CLI provides convenient aliases for different language models. The following model aliases are available:
 
-- `haiku`: Anthropic Claude 3, Haiku 1x
-- `sonnet`: Anthropic Claude 3,  Sonnet 1x
-- `opus` : Anthropic Claude 3,  Opus 1x
-- `mistral7b`: Mistral 7B Instruct 0x
-- `mistral8x7b`: Mistral 8x7B Instruct 0x
-- `mistral-large`: Mistral Large
+* `haiku`: Anthropic Claude 3, Haiku 1x
+* `sonnet`: Anthropic Claude 3, Sonnet 1x
+* `opus`: Anthropic Claude 3, Opus 1x
+* `mistral7b`: Mistral 7B Instruct 0x
+* `mistral8x7b`: Mistral 8x7B Instruct 0x
+* `mistral-large`: Mistral Large
 
 You can use these aliases with the `-M` or `--model` option to specify the desired model for generation.
 
-## Examples
+**Examples**
+------------
 
 Here are a few examples demonstrating the usage of Hiramu CLI:
 
 1. Ask a question using the default options:
-   ```bash
-   hiramu-cli prompt "What is the capital of France?"
-   ```
-
+```bash
+hiramu-cli generate "What is the capital of France?"
+```
 2. Ask a question using a specific model and temperature:
-   ```bash
-   hiramu-cli prompt "What is the meaning of life?" -M sonnet -t 0.5
-   ```
-
+```bash
+hiramu-cli generate "What is the meaning of life?" -M sonnet -t 0.5
+```
 3. Translate text interactively:
-   ```bash
-   hiramu-cli prompt "Translate the following text from English to Spanish: {input}" -M mistral8x7b
-   ```
-
+```bash
+hiramu-cli generate "Translate the following text from English to Spanish: {input}" -M mistral8x7b
+```
 4. Generate a story with a given prompt:
-   ```bash
-   hiramu-cli prompt "Once upon a time, in a far-off land, there lived a brave knight named {input}. The knight embarked on a quest to..." -m 200 -M mistral-large
-   ```
-
+```bash
+hiramu-cli generate "Once upon a time, in a far-off land, there lived a brave knight named {input}. The knight embarked on a quest to..." -m 200 -M mistral-large
+```
 Feel free to explore different prompts, models, and options to generate various types of content using Hiramu CLI.
 
-## Contributing
+**Contributing**
+--------------
 
-Contributions to Hiramu CLI are welcome! If you encounter any issues or have suggestions for improvements, please open an issue on the GitHub repository.
+Contributions to Hiramu CLI are welcome If you encounter any issues or have suggestions for improvements, please open an issue on the GitHub repository.
 
-## License
+**Version**
+----------
+
+### 0.1.16
+
+* Replace `prompt` command with `generate`
+* Support for temperature and maxtoken for Ollama
+
+**License**
+---------
 
 Hiramu CLI is open-source software licensed under the [Apache 2](LICENSE).
+

--- a/src/generator/ollama_provider.rs
+++ b/src/generator/ollama_provider.rs
@@ -3,24 +3,51 @@ use futures_util::TryStreamExt;
 use hiramu::ollama::model::GenerateRequestBuilder;
 use hiramu::ollama::ollama_client::OllamaClient;
 
+use hiramu::ollama::OptionsBuilder;
 use tokio::io::AsyncWriteExt;
 
 pub struct OllamaProvider {
     endpoint: String,
     model: String,
+    maxtoken: Option<u32>,
+    temperature: Option<f32>,
 }
 
 impl OllamaProvider {
-    pub fn new(endpoint: String, model: String) -> OllamaProvider {
-        OllamaProvider { endpoint, model }
+    pub fn new(
+        endpoint: String,
+        model: String,
+        maxtoken: Option<u32>,
+        temperature: Option<f32>,
+    ) -> OllamaProvider {
+        OllamaProvider {
+            endpoint,
+            model,
+            maxtoken,
+            temperature,
+        }
     }
 }
 
 impl Generate for OllamaProvider {
     async fn generate(&self, prompt: &str) -> () {
         let client = OllamaClient::new(self.endpoint.clone());
+
+        let options_builder = OptionsBuilder::new();
+
+        let options_builder = match self.maxtoken {
+            Some(maxtoken) => options_builder.num_predict(maxtoken),
+            None => options_builder,
+        };
+
+        let options_builder = match self.temperature {
+            Some(temperature) => options_builder.temperature(temperature),
+            None => options_builder,
+        };
+
         let request = GenerateRequestBuilder::new(self.model.clone())
-            .prompt(prompt.to_string())
+            .options_from_builder(options_builder)
+            .prompt(prompt.to_owned())
             .build();
 
         let response_stream = client.generate(request).await.unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn version_subcommand() -> Command {
 }
 
 fn prompt_subcommand() -> Command {
-    Command::new("prompt")
+    Command::new("generate")
         .about("Ask a question to a LLM")
         .arg(arg!(<PROMPT> "The prompt to ask. Can contain {input} to read from stdin."))
         .arg(arg!(-r --region <REGION> "The region to use").default_value("us-west-2"))
@@ -73,7 +73,7 @@ async fn generate(
         }
         Provider::Ollama => {
             let endpoint = endpoint.unwrap_or_else(|| "http://localhost:11434".to_string());
-            let ollama_provider = OllamaProvider::new(endpoint, model);
+            let ollama_provider = OllamaProvider::new(endpoint, model, max_token, temperature);
             ollama_provider.generate(&prompt).await;
         }
     }


### PR DESCRIPTION
- Replace `prompt` command with `generate`
- Support for temperature and maxtoken for Ollama
- Update Cargo.lock, Cargo.toml, and README.md to reflect the new version